### PR TITLE
.azurepipelines/templates: Force platform build packages to 0

### DIFF
--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -65,6 +65,9 @@ steps:
     arguments: -c ${{ parameters.build_file }} -t ${{ parameters.build_target}} -a ${{ parameters.build_arch}} --pr-target origin/$(System.PullRequest.targetBranch) --output-count-format-string "##vso[task.setvariable variable=pkg_count;isOutpout=true]{pkgcount}"
   condition: eq(variables['Build.Reason'], 'PullRequest')
 
+# Set default
+- bash: echo "##vso[task.setvariable variable=pkg_count]${{ 0 }}"
+
  # Setup repo
 - task: CmdLine@1
   displayName: Setup


### PR DESCRIPTION
Reduce platform build times for testing purposes by forcing
the number of packages to test to 0.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>