### PR TITLE
.mergify: Remove EDK II Maintainer author checks

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -29,14 +29,12 @@ queue_rules:
     conditions:
       - base~=(^master|^stable/)
       - label=push
-      - author=@tianocore/edk-ii-maintainers
 
 pull_request_rules:
   - name: Automatically merge a PR when all required checks pass and 'push' label is present
     conditions:
       - base~=(^master|^stable/)
       - label=push
-      - author=@tianocore/edk-ii-maintainers
     actions:
       queue:
         method: rebase
@@ -50,12 +48,3 @@ pull_request_rules:
     actions:
       comment:
         message: PR can not be merged due to conflict.  Please rebase and resubmit
-
-  - name: Automatically close a PR that fails the EDK II Maintainers membership check and 'push' label is present
-    conditions:
-      - base~=(^master|^stable/)
-      - label=push
-      - -author=@tianocore/edk-ii-maintainers
-    actions:
-      close:
-        message: PR submitter is not a member of the Tianocore EDK II Maintainers team


### PR DESCRIPTION
Remove checks for PR Author being a member of the EDK II
Maintainers team.  This prevents non EDK II Maintainers from
submitting a PR.  Only EDK II Maintainers are allowed to modify
labels, so a non EDK II Maintainer can never set the 'push'
label.

This change allows non EDK II Maintainers to submit a PR and
go through review and CI.  An EDK II Maintainer can review the
status and set the 'push' label on the existing PR once all the
criteria have been met.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>