### PR TITLE
.github: Add CODEOWNERS and REVIEWERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -201,7 +201,6 @@
 # M: Sami Mujawar <Sami.Mujawar@arm.com> [samimujawar]
 # M: Alexei Fedorov <Alexei.Fedorov@arm.com> [AlexeiFedorov]
 /DynamicTablesPkg/**             @samimujawar @AlexeiFedorov
-/DynamicTablesPkg/**/AArch64/**  @samimujawar @AlexeiFedorov @leiflindholm @ardbiesheuvel
 /DynamicTablesPkg/**/Arm/**      @samimujawar @AlexeiFedorov @leiflindholm @ardbiesheuvel
 
 # EmbeddedPkg
@@ -474,7 +473,6 @@
 /OvmfPkg/**             @ardbiesheuvel @jyao1
 /OvmfPkg/**/AArch64/**  @ardbiesheuvel @jyao1 @leiflindholm
 /OvmfPkg/**/Arm/**      @ardbiesheuvel @jyao1 @leiflindholm
-/OvmfPkg/**/RiscV64/**  @ardbiesheuvel @jyao1 @changab
 
 #
 # OvmfPkg: bhyve-related modules
@@ -601,8 +599,6 @@
 # M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
 /SecurityPkg/**             @jyao1 @jwang36
 /SecurityPkg/**/AArch64/**  @jyao1 @jwang36 @leiflindholm @ardbiesheuvel
-/SecurityPkg/**/Arm/**      @jyao1 @jwang36 @leiflindholm @ardbiesheuvel
-/SecurityPkg/**/RiscV64/**  @jyao1 @jwang36 @changab
 
 # SecurityPkg: Secure boot related modules
 # F: SecurityPkg/Library/DxeImageVerificationLib/
@@ -621,9 +617,7 @@
 # M: Ray Ni <ray.ni@intel.com> [niruiyu]
 # M: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
 /ShellPkg/**             @niruiyu @ZhichaoGao
-/ShellPkg/**/AArch64/**  @niruiyu @ZhichaoGao @leiflindholm @ardbiesheuvel
 /ShellPkg/**/Arm/**      @niruiyu @ZhichaoGao @leiflindholm @ardbiesheuvel
-/ShellPkg/**/RiscV64/**  @niruiyu @ZhichaoGao @changab
 
 # SignedCapsulePkg
 # F: SignedCapsulePkg/
@@ -646,7 +640,6 @@
 /StandaloneMmPkg/**             @ardbiesheuvel @samimujawar @jyao1
 /StandaloneMmPkg/**/AArch64/**  @ardbiesheuvel @samimujawar @jyao1 @leiflindholm
 /StandaloneMmPkg/**/Arm/**      @ardbiesheuvel @samimujawar @jyao1 @leiflindholm
-/StandaloneMmPkg/**/RiscV64/**  @ardbiesheuvel @samimujawar @jyao1 @changab
 
 # UefiCpuPkg
 # F: UefiCpuPkg/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,684 @@
+## @file
+#  CODEOWNERS file that contains EDK II Maintainers
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+#
+# EDK II Maintainers
+# ==================
+#
+# This file provides information about the primary maintainers for
+# EDK II.
+#
+# In general, you should not privately email the maintainer. You should
+# email the edk2-devel list, and Cc the package maintainers and
+# reviewers.
+#
+# If the package maintainer wants to hand over the role to other people,
+# the package maintainer should send the patch to update Maintainers.txt
+# with new maintainer, and the new maintainer should follow up with
+# an Acked-by or a Reviewed-by.
+#
+# Descriptions of section entries:
+#
+#   L: Mailing list that is relevant to this area (default is edk2-devel)
+#      Patches and questions should be sent to the email list.
+#   M: Package Maintainer: Cc address for patches and questions. Responsible
+#      for reviewing and pushing package changes to source control.
+#   R: Package Reviewer: Cc address for patches and questions. Reviewers help
+#      maintainers review code, but don't have push access. A designated Package
+#      Reviewer is reasonably familiar with the Package (or some modules
+#      thereof), and/or provides testing or regression testing for the Package
+#      (or some modules thereof), in certain platforms and environments.
+#   W: Web-page with status/info
+#   T: SCM tree type and location.  Type is one of: git, svn.
+#   S: Status, one of the following:
+#      Supported:  Someone is actually paid to look after this.
+#      Maintained: Someone actually looks after it.
+#      Odd Fixes:  It has a maintainer but they don't have time to do
+#                  much other than throw the odd patch in. See below.
+#      Orphan:     No current maintainer [but maybe you could take the
+#                  role as you write your new code].
+#      Obsolete:   Old code. Something tagged obsolete generally means
+#                  it has been replaced by a better system and you
+#                  should be using that.
+#   F: Files and directories with wildcard patterns.
+#      A trailing slash includes all files and subdirectory files.
+#      F:   MdeModulePkg/   all files in and below MdeModulePkg
+#      F:   MdeModulePkg/*  all files in MdeModulePkg, but not below
+#      F:   */Pci/*         all files in a directory called Pci, at any depth in
+#                           the hierarchy, but not below
+#      One pattern per line.  Multiple F: lines per section acceptable.
+#   X: Files and directories that are NOT maintained, same rules as F:
+#      Files exclusions are tested after file matches.
+#      Can be useful for excluding a specific subdirectory, for instance:
+#      F:   NetworkPkg/
+#      X:   NetworkPkg/Ip6Dxe/
+#      matches all files in and below NetworkPkg excluding NetworkPkg/Ip6Dxe/
+#   Filenames not caught by any F: rule get matched as being located in the top-
+#   level directory. (Internally, the script looks for a match called '<default>',
+#   so please don't add a file called that in the top-level directory.)
+#
+# EDK II
+# ------
+# W: http://www.tianocore.org/edk2/
+# L: https://edk2.groups.io/g/devel/
+# T: git - https://github.com/tianocore/edk2.git
+# T: git (mirror) - https://bitbucket.org/tianocore/edk2.git
+#
+# All patches CC:d here
+# L: devel@edk2.groups.io
+# F: *
+# F: */
+#
+# Tianocore Stewards
+# ------------------
+# F: *
+# M: Andrew Fish <afish@apple.com> [ajfish]
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+*                @ajfish  @leiflindholm  @mdkinney
+
+# Responsible Disclosure, Reporting Security Issues
+# -------------------------------------------------
+# W: https://github.com/tianocore/tianocore.github.io/wiki/Security
+#
+# EDK II Releases:
+# ----------------
+# W: https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Release-Planning
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+#
+# UEFI Shell Binaries (ShellBinPkg.zip) from EDK II Releases:
+# -----------------------------------------------------------
+# W: https://github.com/tianocore/edk2/releases/
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]                        (Ia32/X64)
+# M: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]           (Ia32/X64)
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]           (ARM/AArch64)
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel] (ARM/AArch64)
+#
+# EDK II Architectures:
+# ---------------------
+# ARM, AARCH64
+# F: */AArch64/
+# F: */Arm/
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+#
+# RISCV64
+# F: */RiscV64/
+# M: Sunil V L <sunilvl@ventanamicro.com> [vlsunil]
+# R: Daniel Schaefer <git@danielschaefer.me> [JohnAZoidberg]
+#
+# EDK II Continuous Integration:
+# ------------------------------
+# .azurepipelines/
+# F: .azurepipelines/
+# M: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# M: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+# R: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/.azurepipelines/**  @spbrogan @corthon
+
+# .mergify/
+# F: .mergify/
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# R: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+/.mergify/**  @mdkinney @lgao4
+
+# .pytool/
+# F: .pytool/
+# M: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# M: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+# R: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/.pytool/**  @spbrogan @corthon
+
+# EDK II Packages:
+# ----------------
+# ArmPkg
+# F: ArmPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ArmPkg
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# R: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
+/ArmPkg/**  @leiflindholm @ardbiesheuvel
+
+# ArmPlatformPkg
+# F: ArmPlatformPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ArmPlatformPkg
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+/ArmPlatformPkg/**  @leiflindholm @ardbiesheuvel
+
+# ArmVirtPkg
+# F: ArmVirtPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ArmVirtPkg
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# R: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# R: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+/ArmVirtPkg/**             @ardbiesheuvel
+/ArmVirtPkg/**/AArch64/**  @ardbiesheuvel @leiflindholm
+/ArmVirtPkg/**/Arm/**      @ardbiesheuvel @leiflindholm
+
+# ArmVirtPkg: modules used on Xen
+# F: ArmVirtPkg/ArmVirtXen.*
+# F: ArmVirtPkg/Library/XenArmGenericTimerVirtCounterLib/
+# F: ArmVirtPkg/Library/XenVirtMemInfoLib/
+# F: ArmVirtPkg/PrePi/
+# F: ArmVirtPkg/XenAcpiPlatformDxe/
+# F: ArmVirtPkg/XenPlatformHasAcpiDtDxe/
+# F: ArmVirtPkg/XenioFdtDxe/
+# R: Julien Grall <julien@xen.org> [jgrall]
+
+# BaseTools
+# F: BaseTools/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/BaseTools
+# M: Bob Feng <bob.c.feng@intel.com> [BobCF]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Yuwei Chen <yuwei.chen@intel.com> [YuweiChen1110]
+/BaseTools/**             @BobCF @lgao4
+/BaseTools/**/AArch64/**  @BobCF @lgao4 @leiflindholm @ardbiesheuvel
+/BaseTools/**/Arm/**      @BobCF @lgao4 @leiflindholm @ardbiesheuvel
+/BaseTools/**/RiscV64/**  @BobCF @lgao4 @vlsunil
+
+# CryptoPkg
+# F: CryptoPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/CryptoPkg
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+# R: Xiaoyu Lu <xiaoyu1.lu@intel.com> [xiaoyuxlu]
+# R: Guomin Jiang <guomin.jiang@intel.com> [guominjia]
+/CryptoPkg/**  @jyao1 @jwang36
+
+# DynamicTablesPkg
+# F: DynamicTablesPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/DynamicTablesPkg
+# M: Sami Mujawar <Sami.Mujawar@arm.com> [samimujawar]
+# M: Alexei Fedorov <Alexei.Fedorov@arm.com> [AlexeiFedorov]
+/DynamicTablesPkg/**             @samimujawar @AlexeiFedorov
+/DynamicTablesPkg/**/AArch64/**  @samimujawar @AlexeiFedorov @leiflindholm @ardbiesheuvel
+/DynamicTablesPkg/**/Arm/**      @samimujawar @AlexeiFedorov @leiflindholm @ardbiesheuvel
+
+# EmbeddedPkg
+# F: EmbeddedPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/EmbeddedPkg
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# M: Abner Chang <abner.chang@amd.com> [changab]
+# R: Daniel Schaefer <git@danielschaefer.me> [JohnAZoidberg]
+/EmbeddedPkg/**  @leiflindholm @ardbiesheuvel @changab
+
+# EmulatorPkg
+# F: EmulatorPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/EmulatorPkg
+# M: Andrew Fish <afish@apple.com> [ajfish]
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# S: Maintained
+/EmulatorPkg/**  @ajfish @niruiyu
+
+# EmulatorPkg: Redfish-related modules
+# F: EmulatorPkg/*Redfish*
+# M: Abner Chang <abner.chang@amd.com> [changab]
+# R: Nickle Wang <nickle@csie.io> [nicklela]
+/EmulatorPkg/**/Redfish*/**  @ajfish @niruiyu @changab
+
+# FatPkg
+# F: FatPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/Edk2-fat-driver
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# T: svn - https://svn.code.sf.net/p/edk2-fatdriver2/code/trunk/EnhancedFat
+# T: git - https://github.com/tianocore/edk2-FatPkg.git
+/FatPkg/**  @niruiyu
+
+# FmpDevicePkg
+# F: FmpDevicePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/FmpDevicePkg
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# R: Guomin Jiang <guomin.jiang@intel.com> [guominjia]
+# R: Wei6 Xu <wei6.xu@intel.com> [xuweiintel]
+/FmpDevicePkg/**  @lgao4 @mdkinney
+
+# IntelFsp2Pkg
+# F: IntelFsp2Pkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/IntelFsp2Pkg
+# M: Chasel Chiu <chasel.chiu@intel.com> [ChaselChiu]
+# M: Nate DeSimone <nathaniel.l.desimone@intel.com> [nate-desimone]
+# R: Star Zeng <star.zeng@intel.com> [lzeng14]
+/IntelFsp2Pkg/**  @ChaselChiu @nate-desimone
+
+# IntelFsp2WrapperPkg
+# F: IntelFsp2WrapperPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/IntelFsp2WrapperPkg
+# M: Chasel Chiu <chasel.chiu@intel.com> [ChaselChiu]
+# M: Nate DeSimone <nathaniel.l.desimone@intel.com> [nate-desimone]
+# R: Star Zeng <star.zeng@intel.com> [lzeng14]
+/IntelFsp2WrapperPkg/**  @ChaselChiu @nate-desimone
+
+# MdeModulePkg
+# F: MdeModulePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/MdeModulePkg
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/MdeModulePkg/**             @jwang36 @lgao4
+/MdeModulePkg/**/AArch64/**  @jwang36 @lgao4 @leiflindholm @ardbiesheuvel
+/MdeModulePkg/**/Arm/**      @jwang36 @lgao4 @leiflindholm @ardbiesheuvel
+/MdeModulePkg/**/RiscV64/**  @jwang36 @lgao4 @vlsunil
+
+# MdeModulePkg: ACPI modules
+# F: MdeModulePkg/Include/*Acpi*.h
+# F: MdeModulePkg/Universal/Acpi/
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+
+# MdeModulePkg: ACPI modules related to S3
+# F: MdeModulePkg/*LockBox*/
+# F: MdeModulePkg/Include/*BootScript*.h
+# F: MdeModulePkg/Include/*LockBox*.h
+# F: MdeModulePkg/Include/*S3*.h
+# F: MdeModulePkg/Library/*S3*/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Eric Dong <eric.dong@intel.com> [ydong10]
+
+# MdeModulePkg: BDS modules
+# F: MdeModulePkg/*BootManager*/
+# F: MdeModulePkg/Include/Library/UefiBootManagerLib.h
+# F: MdeModulePkg/Universal/BdsDxe/
+# F: MdeModulePkg/Universal/DevicePathDxe/
+# F: MdeModulePkg/Universal/DriverHealthManagerDxe/
+# F: MdeModulePkg/Universal/LoadFileOnFv2/
+# F: MdeModulePkg/Universal/SecurityStubDxe/Defer3rdPartyImageLoad.*
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+
+# MdeModulePkg: Console and Graphics modules
+# F: MdeModulePkg/*Logo*/
+# F: MdeModulePkg/Include/*Logo*.h
+# F: MdeModulePkg/Include/Guid/ConnectConInEvent.h
+# F: MdeModulePkg/Include/Guid/Console*.h
+# F: MdeModulePkg/Include/Guid/StandardErrorDevice.h
+# F: MdeModulePkg/Include/Guid/TtyTerm.h
+# F: MdeModulePkg/Include/Library/BmpSupportLib.h
+# F: MdeModulePkg/Include/Library/FrameBufferBltLib.h
+# F: MdeModulePkg/Library/BaseBmpSupportLib/
+# F: MdeModulePkg/Library/FrameBufferBltLib/
+# F: MdeModulePkg/Universal/Console/
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+
+# MdeModulePkg: Core services (PEI, DXE and Runtime) modules
+# F: MdeModulePkg/*Mem*/
+# F: MdeModulePkg/*SectionExtract*/
+# F: MdeModulePkg/*StatusCode*/
+# F: MdeModulePkg/Application/DumpDynPcd/
+# F: MdeModulePkg/Core/Dxe/
+# F: MdeModulePkg/Core/DxeIplPeim/
+# F: MdeModulePkg/Core/RuntimeDxe/
+# F: MdeModulePkg/Include/*Mem*.h
+# F: MdeModulePkg/Include/*Pcd*.h
+# F: MdeModulePkg/Include/*Perf*.h
+# F: MdeModulePkg/Include/*StatusCode*.h
+# F: MdeModulePkg/Include/Guid/Crc32GuidedSectionExtraction.h
+# F: MdeModulePkg/Include/Guid/EventExitBootServiceFailed.h
+# F: MdeModulePkg/Include/Guid/IdleLoopEvent.h
+# F: MdeModulePkg/Include/Guid/LoadModuleAtFixedAddress.h
+# F: MdeModulePkg/Include/Guid/LzmaDecompress.h
+# F: MdeModulePkg/Include/Library/SecurityManagementLib.h
+# F: MdeModulePkg/Library/*Decompress*/
+# F: MdeModulePkg/Library/*Perf*/
+# F: MdeModulePkg/Library/DxeSecurityManagementLib/
+# F: MdeModulePkg/Universal/PCD/
+# F: MdeModulePkg/Universal/PlatformDriOverrideDxe/
+# F: MdeModulePkg/Universal/SecurityStubDxe/SecurityStub.c
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+
+# MdeModulePkg: Device and Peripheral modules
+# F: MdeModulePkg/*PciHostBridge*/
+# F: MdeModulePkg/Bus/
+# F: MdeModulePkg/Include/*Ata*.h
+# F: MdeModulePkg/Include/*IoMmu*.h
+# F: MdeModulePkg/Include/*NonDiscoverableDevice*.h
+# F: MdeModulePkg/Include/*NvmExpress*.h
+# F: MdeModulePkg/Include/*SdMmc*.h
+# F: MdeModulePkg/Include/*Ufs*.h
+# F: MdeModulePkg/Include/*Usb*.h
+# F: MdeModulePkg/Include/Guid/RecoveryDevice.h
+# F: MdeModulePkg/Include/Guid/S3StorageDeviceInitList.h
+# F: MdeModulePkg/Include/Library/PciHostBridgeLib.h
+# F: MdeModulePkg/Include/Ppi/StorageSecurityCommand.h
+# F: MdeModulePkg/Include/Protocol/Ps2Policy.h
+# F: MdeModulePkg/Library/NonDiscoverableDeviceRegistrationLib/
+# F: MdeModulePkg/Universal/PcatSingleSegmentPciCfg2Pei/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+
+# MdeModulePkg: Disk modules
+# F: MdeModulePkg/Universal/Disk/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+
+# MdeModulePkg: Firmware Update modules
+# F: MdeModulePkg/*Capsule*/
+# F: MdeModulePkg/Include/*Capsule*.h
+# F: MdeModulePkg/Include/Library/DisplayUpdateProgressLib.h
+# F: MdeModulePkg/Include/Library/FmpAuthenticationLib.h
+# F: MdeModulePkg/Include/Protocol/EsrtManagement.h
+# F: MdeModulePkg/Include/Protocol/FirmwareManagementProgress.h
+# F: MdeModulePkg/Library/DisplayUpdateProgressLib*/
+# F: MdeModulePkg/Library/FmpAuthenticationLibNull/
+# F: MdeModulePkg/Universal/Esrt*/
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Guomin Jiang <guomin.jiang@intel.com> [guominjia]
+
+# MdeModulePkg: HII and UI modules
+# F: MdeModulePkg/*FileExplorer*/
+# F: MdeModulePkg/*Hii*/
+# F: MdeModulePkg/*Ui*/
+# F: MdeModulePkg/Application/BootManagerMenuApp/
+# F: MdeModulePkg/Include/*FileExplorer*.h
+# F: MdeModulePkg/Include/*FormBrowser*.h
+# F: MdeModulePkg/Include/*Hii*.h
+# F: MdeModulePkg/Include/Library/CustomizedDisplayLib.h
+# F: MdeModulePkg/Include/Protocol/DisplayProtocol.h
+# F: MdeModulePkg/Library/CustomizedDisplayLib/
+# F: MdeModulePkg/Universal/DisplayEngineDxe/
+# F: MdeModulePkg/Universal/DriverSampleDxe/
+# F: MdeModulePkg/Universal/SetupBrowserDxe/
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Eric Dong <eric.dong@intel.com> [ydong10]
+
+# MdeModulePkg: Management Mode (MM, SMM) modules
+# F: MdeModulePkg/*Smi*/
+# F: MdeModulePkg/*Smm*/
+# F: MdeModulePkg/Include/*Smi*.h
+# F: MdeModulePkg/Include/*Smm*.h
+# R: Eric Dong <eric.dong@intel.com> [ydong10]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+
+# MdeModulePkg: Reset modules
+# F: MdeModulePkg/*Reset*/
+# F: MdeModulePkg/Include/*Reset*.h
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+
+# MdeModulePkg: Pei Core
+# F: MdeModulePkg/Core/Pei/
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Debkumar De <debkumar.de@intel.com> [dde01]
+# R: Catharine West <catharine.west@intel.com> [catharine-intl]
+
+# MdeModulePkg: Serial modules
+# F: MdeModulePkg/*Serial*/
+# F: MdeModulePkg/Include/*SerialPort*.h
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+
+# MdeModulePkg: SMBIOS modules
+# F: MdeModulePkg/Universal/Smbios*/
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Star Zeng <star.zeng@intel.com> [lzeng14]
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+
+# MdeModulePkg: UEFI Variable modules
+# F: MdeModulePkg/*Var*/
+# F: MdeModulePkg/Include/*/*FaultTolerantWrite*.h
+# F: MdeModulePkg/Include/*/*Var*.h
+# F: MdeModulePkg/Include/Guid/SystemNvDataGuid.h
+# F: MdeModulePkg/Include/Protocol/SwapAddressRange.h
+# F: MdeModulePkg/Universal/FaultTolerantWrite*/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+
+# MdeModulePkg: Universal Payload definitions
+# F: MdeModulePkg/Include/UniversalPayload/
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Gua Guo <gua.guo@intel.com> [gguo11837463]
+# MdePkg
+# F: MdePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/MdePkg
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+/MdePkg/**             @mdkinney @lgao4
+/MdePkg/**/AArch64/**  @mdkinney @lgao4 @leiflindholm @ardbiesheuvel
+/MdePkg/**/Arm/**      @mdkinney @lgao4 @leiflindholm @ardbiesheuvel
+/MdePkg/**/RiscV64/**  @mdkinney @lgao4 @vlsunil
+
+# NetworkPkg
+# F: NetworkPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/NetworkPkg
+# M: Maciej Rabeda <maciej.rabeda@linux.intel.com> [mrabeda]
+# R: Jiaxin Wu <jiaxin.wu@intel.com> [jiaxinwu]
+# R: Siyuan Fu <siyuan.fu@intel.com> [sfu5]
+/NetworkPkg/**  @mrabeda
+
+# OvmfPkg
+# F: OvmfPkg/
+# W: http://www.tianocore.org/ovmf/
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# R: Jordan Justen <jordan.l.justen@intel.com> [jljusten]
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+# S: Maintained
+/OvmfPkg/**             @ardbiesheuvel @jyao1
+/OvmfPkg/**/AArch64/**  @ardbiesheuvel @jyao1 @leiflindholm
+/OvmfPkg/**/Arm/**      @ardbiesheuvel @jyao1 @leiflindholm
+/OvmfPkg/**/RiscV64/**  @ardbiesheuvel @jyao1 @changab
+
+#
+# OvmfPkg: bhyve-related modules
+# F: OvmfPkg/Bhyve/
+# F: OvmfPkg/Include/IndustryStandard/Bhyve.h
+# F: OvmfPkg/Include/Library/BhyveFwCtlLib.h
+# F: OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.c
+# F: OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.inf
+# F: OvmfPkg/Library/BhyveFwCtlLib/
+# F: OvmfPkg/Library/PciHostBridgeLibScan/
+# F: OvmfPkg/Library/PlatformBootManagerLibBhyve/
+# F: OvmfPkg/Library/ResetSystemLib/BaseResetShutdownBhyve.c
+# F: OvmfPkg/Library/ResetSystemLib/BaseResetSystemLibBhyve.inf
+# R: Rebecca Cran <rebecca@bsdio.com> [bcran]
+# R: Peter Grehan <grehan@freebsd.org> [grehan-freebsd]
+
+# OvmfPkg: cloudhv-related modules
+# F: OvmfPkg/CloudHv/
+# F: OvmfPkg/Include/IndustryStandard/CloudHv.h
+# R: Sebastien Boeuf <sebastien.boeuf@intel.com> [sboeuf]
+
+# OvmfPkg: microvm-related modules
+# F: OvmfPkg/Microvm/
+# F: OvmfPkg/Include/IndustryStandard/Microvm.h
+# F: OvmfPkg/Library/ResetSystemLib/*Microvm.*
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+
+# OvmfPkg: CSM modules
+# F: OvmfPkg/Csm/
+# R: David Woodhouse <dwmw2@infradead.org> [dwmw2]
+
+# OvmfPkg: Confidential Computing
+# F: OvmfPkg/AmdSev/
+# F: OvmfPkg/AmdSevDxe/
+# F: OvmfPkg/Include/Guid/ConfidentialComputingSecret.h
+# F: OvmfPkg/Include/Library/MemEncryptSevLib.h
+# F: OvmfPkg/IoMmuDxe/AmdSevIoMmu.*
+# F: OvmfPkg/Library/BaseMemEncryptSevLib/
+# F: OvmfPkg/Library/PlatformBootManagerLibGrub/
+# F: OvmfPkg/Library/VmgExitLib/
+# F: OvmfPkg/PlatformPei/AmdSev.c
+# F: OvmfPkg/ResetVector/
+# F: OvmfPkg/Sec/
+# R: Brijesh Singh <brijesh.singh@amd.com> [codomania]
+# R: Erdem Aktas <erdemaktas@google.com> [ruleof2]
+# R: James Bottomley <jejb@linux.ibm.com> [jejb]
+# R: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# R: Min Xu <min.m.xu@intel.com> [mxu9]
+# R: Tom Lendacky <thomas.lendacky@amd.com> [tlendacky]
+
+# OvmfPkg: FDT related modules
+# F: OvmfPkg/Fdt
+# R: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+# R: Abner Chang <abner.chang@amd.com> [changab]
+
+# OvmfPkg: LsiScsi driver
+# F: OvmfPkg/LsiScsiDxe/
+# R: Gary Lin <gary.lin@hpe.com> [lcp]
+
+# OvmfPkg: TCG- and TPM2-related modules
+# F: OvmfPkg/Include/IndustryStandard/QemuTpm.h
+# F: OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+# F: OvmfPkg/Library/Tcg2PhysicalPresenceLib*/
+# F: OvmfPkg/PlatformPei/ClearCache.c
+# F: OvmfPkg/Tcg/
+# R: Marc-André Lureau <marcandre.lureau@redhat.com> [elmarco]
+# R: Stefan Berger <stefanb@linux.ibm.com> [stefanberger]
+
+# OvmfPkg: Xen-related modules
+# F: OvmfPkg/Include/Guid/XenBusRootDevice.h
+# F: OvmfPkg/Include/Guid/XenInfo.h
+# F: OvmfPkg/Include/IndustryStandard/Xen/
+# F: OvmfPkg/Include/Library/XenHypercallLib.h
+# F: OvmfPkg/Include/Library/XenIoMmioLib.h
+# F: OvmfPkg/Include/Library/XenPlatformLib.h
+# F: OvmfPkg/Include/Protocol/XenBus.h
+# F: OvmfPkg/Include/Protocol/XenIo.h
+# F: OvmfPkg/Library/PciHostBridgeLibScan/
+# F: OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+# F: OvmfPkg/Library/XenConsoleSerialPortLib/
+# F: OvmfPkg/Library/XenHypercallLib/
+# F: OvmfPkg/Library/XenIoMmioLib/
+# F: OvmfPkg/Library/XenPlatformLib/
+# F: OvmfPkg/Library/XenRealTimeClockLib/
+# F: OvmfPkg/OvmfXen.*
+# F: OvmfPkg/OvmfXenElfHeaderGenerator.c
+# F: OvmfPkg/SmbiosPlatformDxe/*Xen*
+# F: OvmfPkg/XenAcpiPlatformDxe/
+# F: OvmfPkg/XenBusDxe/
+# F: OvmfPkg/XenIoPciDxe/
+# F: OvmfPkg/XenIoPvhDxe/
+# F: OvmfPkg/XenPlatformPei/
+# F: OvmfPkg/XenPvBlkDxe/
+# F: OvmfPkg/XenResetVector/
+# R: Anthony Perard <anthony.perard@citrix.com> [sheep]
+# R: Julien Grall <julien@xen.org> [jgrall]
+
+# PcAtChipsetPkg
+# F: PcAtChipsetPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/PcAtChipsetPkg
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+/PcAtChipsetPkg/**  @niruiyu
+
+# PrmPkg
+# F: PrmPkg/
+# M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
+# M: Nate DeSimone <nathaniel.l.desimone@intel.com> [nate-desimone]
+/PrmPkg/**  @makubacki @nate-desimone
+
+# PrmPkg: ACPI related modules
+# R: Ankit Sinha <ankit.sinha@intel.com> [ankit13s]
+
+# RedfishPkg: Redfish related modules
+# F: RedfishPkg/
+# M: Abner Chang <abner.chang@amd.com> [changab]
+# R: Nickle Wang <nickle@csie.io> [nicklela]
+/RedfishPkg/**  @changab
+
+# SecurityPkg
+# F: SecurityPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/SecurityPkg
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+/SecurityPkg/**             @jyao1 @jwang36
+/SecurityPkg/**/AArch64/**  @jyao1 @jwang36 @leiflindholm @ardbiesheuvel
+/SecurityPkg/**/Arm/**      @jyao1 @jwang36 @leiflindholm @ardbiesheuvel
+/SecurityPkg/**/RiscV64/**  @jyao1 @jwang36 @changab
+
+# SecurityPkg: Secure boot related modules
+# F: SecurityPkg/Library/DxeImageVerificationLib/
+# F: SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/
+# F: SecurityPkg/Library/AuthVariableLib/
+# R: Min Xu <min.m.xu@intel.com> [mxu9]
+
+# SecurityPkg: Tcg related modules
+# F: SecurityPkg/Tcg/
+# R: Qi Zhang <qi1.zhang@intel.com> [qizhangz]
+# R: Rahul Kumar <rahul1.kumar@intel.com> [rahul1-kumar]
+
+# ShellPkg
+# F: ShellPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ShellPkg
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# M: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+/ShellPkg/**             @niruiyu @ZhichaoGao
+/ShellPkg/**/AArch64/**  @niruiyu @ZhichaoGao @leiflindholm @ardbiesheuvel
+/ShellPkg/**/Arm/**      @niruiyu @ZhichaoGao @leiflindholm @ardbiesheuvel
+/ShellPkg/**/RiscV64/**  @niruiyu @ZhichaoGao @changab
+
+# SignedCapsulePkg
+# F: SignedCapsulePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/SignedCapsulePkg
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+/SignedCapsulePkg/**  @jwang36
+
+# SourceLevelDebugPkg
+# F: SourceLevelDebugPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/SourceLevelDebugPkg
+# M: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+/SourceLevelDebugPkg/**  @hwu25
+
+# StandaloneMmPkg
+# F: StandaloneMmPkg/
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# M: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# R: Supreeth Venkatesh <supreeth.venkatesh@arm.com> [supven01]
+/StandaloneMmPkg/**             @ardbiesheuvel @samimujawar @jyao1
+/StandaloneMmPkg/**/AArch64/**  @ardbiesheuvel @samimujawar @jyao1 @leiflindholm
+/StandaloneMmPkg/**/Arm/**      @ardbiesheuvel @samimujawar @jyao1 @leiflindholm
+/StandaloneMmPkg/**/RiscV64/**  @ardbiesheuvel @samimujawar @jyao1 @changab
+
+# UefiCpuPkg
+# F: UefiCpuPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/UefiCpuPkg
+# M: Eric Dong <eric.dong@intel.com> [ydong10]
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Rahul Kumar <rahul1.kumar@intel.com> [rahul1-kumar]
+/UefiCpuPkg/**  @ydong10 @niruiyu
+
+# UefiCpuPkg: Sec related modules
+# F: UefiCpuPkg/SecCore/
+# F: UefiCpuPkg/ResetVector/
+# R: Debkumar De <debkumar.de@intel.com> [dde01]
+# R: Catharine West <catharine.west@intel.com> [catharine-intl]
+
+# UefiPayloadPkg
+# F: UefiPayloadPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/UefiPayloadPkg
+# M: Guo Dong <guo.dong@intel.com> [gdong1]
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# M: Sean Rhodes <sean@starlabs.systems> [Sean-StarLabs]
+# M: James Lu <james.lu@intel.com> [jameslu8]
+# R: Gua Guo <gua.guo@intel.com> [gguo11837463]
+# S: Maintained
+/UefiPayloadPkg/**  @gdong1 @niruiyu @Sean-StarLabs @jameslu8
+
+# UnitTestFrameworkPkg
+# F: UnitTestFrameworkPkg/
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
+# R: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# R: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+# S: Maintained
+/UnitTestFrameworkPkg/**  @mdkinney @makubacki
+

--- a/.github/REVIEWERS
+++ b/.github/REVIEWERS
@@ -1,0 +1,862 @@
+## @file
+#  REVIEWERS file that contains EDK II Reviewers
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+#
+# EDK II Maintainers
+# ==================
+#
+# This file provides information about the primary maintainers for
+# EDK II.
+#
+# In general, you should not privately email the maintainer. You should
+# email the edk2-devel list, and Cc the package maintainers and
+# reviewers.
+#
+# If the package maintainer wants to hand over the role to other people,
+# the package maintainer should send the patch to update Maintainers.txt
+# with new maintainer, and the new maintainer should follow up with
+# an Acked-by or a Reviewed-by.
+#
+# Descriptions of section entries:
+#
+#   L: Mailing list that is relevant to this area (default is edk2-devel)
+#      Patches and questions should be sent to the email list.
+#   M: Package Maintainer: Cc address for patches and questions. Responsible
+#      for reviewing and pushing package changes to source control.
+#   R: Package Reviewer: Cc address for patches and questions. Reviewers help
+#      maintainers review code, but don't have push access. A designated Package
+#      Reviewer is reasonably familiar with the Package (or some modules
+#      thereof), and/or provides testing or regression testing for the Package
+#      (or some modules thereof), in certain platforms and environments.
+#   W: Web-page with status/info
+#   T: SCM tree type and location.  Type is one of: git, svn.
+#   S: Status, one of the following:
+#      Supported:  Someone is actually paid to look after this.
+#      Maintained: Someone actually looks after it.
+#      Odd Fixes:  It has a maintainer but they don't have time to do
+#                  much other than throw the odd patch in. See below.
+#      Orphan:     No current maintainer [but maybe you could take the
+#                  role as you write your new code].
+#      Obsolete:   Old code. Something tagged obsolete generally means
+#                  it has been replaced by a better system and you
+#                  should be using that.
+#   F: Files and directories with wildcard patterns.
+#      A trailing slash includes all files and subdirectory files.
+#      F:   MdeModulePkg/   all files in and below MdeModulePkg
+#      F:   MdeModulePkg/*  all files in MdeModulePkg, but not below
+#      F:   */Pci/*         all files in a directory called Pci, at any depth in
+#                           the hierarchy, but not below
+#      One pattern per line.  Multiple F: lines per section acceptable.
+#   X: Files and directories that are NOT maintained, same rules as F:
+#      Files exclusions are tested after file matches.
+#      Can be useful for excluding a specific subdirectory, for instance:
+#      F:   NetworkPkg/
+#      X:   NetworkPkg/Ip6Dxe/
+#      matches all files in and below NetworkPkg excluding NetworkPkg/Ip6Dxe/
+#   Filenames not caught by any F: rule get matched as being located in the top-
+#   level directory. (Internally, the script looks for a match called '<default>',
+#   so please don't add a file called that in the top-level directory.)
+#
+# EDK II
+# ------
+# W: http://www.tianocore.org/edk2/
+# L: https://edk2.groups.io/g/devel/
+# T: git - https://github.com/tianocore/edk2.git
+# T: git (mirror) - https://bitbucket.org/tianocore/edk2.git
+#
+# All patches CC:d here
+# L: devel@edk2.groups.io
+# F: *
+# F: */
+#
+# Tianocore Stewards
+# ------------------
+# F: *
+# M: Andrew Fish <afish@apple.com> [ajfish]
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+#
+# Responsible Disclosure, Reporting Security Issues
+# -------------------------------------------------
+# W: https://github.com/tianocore/tianocore.github.io/wiki/Security
+#
+# EDK II Releases:
+# ----------------
+# W: https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Release-Planning
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+#
+# UEFI Shell Binaries (ShellBinPkg.zip) from EDK II Releases:
+# -----------------------------------------------------------
+# W: https://github.com/tianocore/edk2/releases/
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]                        (Ia32/X64)
+# M: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]           (Ia32/X64)
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]           (ARM/AArch64)
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel] (ARM/AArch64)
+#
+# EDK II Architectures:
+# ---------------------
+# ARM, AARCH64
+# F: */AArch64/
+# F: */Arm/
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+#
+# RISCV64
+# F: */RiscV64/
+# M: Sunil V L <sunilvl@ventanamicro.com> [vlsunil]
+# R: Daniel Schaefer <git@danielschaefer.me> [JohnAZoidberg]
+#
+# EDK II Continuous Integration:
+# ------------------------------
+# .azurepipelines/
+# F: .azurepipelines/
+# M: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# M: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+# R: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/.azurepipelines/**  @mdkinney @lgao4
+
+# .mergify/
+# F: .mergify/
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# R: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+/.mergify/**  @spbrogan @corthon
+
+# .pytool/
+# F: .pytool/
+# M: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# M: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+# R: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/.pytool/**  @mdkinney @lgao4
+
+# EDK II Packages:
+# ----------------
+# ArmPkg
+# F: ArmPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ArmPkg
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# R: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
+/ArmPkg/**  @samimujawar
+
+# ArmPlatformPkg
+# F: ArmPlatformPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ArmPlatformPkg
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+
+# ArmVirtPkg
+# F: ArmVirtPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ArmVirtPkg
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# R: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# R: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+/ArmVirtPkg/**  @leiflindholm @samimujawar @kraxel
+
+# ArmVirtPkg: modules used on Xen
+# F: ArmVirtPkg/ArmVirtXen.*
+# F: ArmVirtPkg/Library/XenArmGenericTimerVirtCounterLib/
+# F: ArmVirtPkg/Library/XenVirtMemInfoLib/
+# F: ArmVirtPkg/PrePi/
+# F: ArmVirtPkg/XenAcpiPlatformDxe/
+# F: ArmVirtPkg/XenPlatformHasAcpiDtDxe/
+# F: ArmVirtPkg/XenioFdtDxe/
+# R: Julien Grall <julien@xen.org> [jgrall]
+/ArmVirtPkg/ArmVirtXen.*                                 @leiflindholm @samimujawar @kraxel @jgrall
+/ArmVirtPkg/Library/XenArmGenericTimerVirtCounterLib/**  @leiflindholm @samimujawar @kraxel @jgrall
+/ArmVirtPkg/Library/XenVirtMemInfoLib/**                 @leiflindholm @samimujawar @kraxel @jgrall
+/ArmVirtPkg/PrePi/**                                     @leiflindholm @samimujawar @kraxel @jgrall
+/ArmVirtPkg/XenAcpiPlatformDxe/**                        @leiflindholm @samimujawar @kraxel @jgrall
+/ArmVirtPkg/XenPlatformHasAcpiDtDxe/**                   @leiflindholm @samimujawar @kraxel @jgrall
+/ArmVirtPkg/XenioFdtDxe/**                               @leiflindholm @samimujawar @kraxel @jgrall
+
+# BaseTools
+# F: BaseTools/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/BaseTools
+# M: Bob Feng <bob.c.feng@intel.com> [BobCF]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Yuwei Chen <yuwei.chen@intel.com> [YuweiChen1110]
+/BaseTools/**             @YuweiChen1110
+/BaseTools/**/RiscV64/**  @YuweiChen1110 @JohnAZoidberg
+
+# CryptoPkg
+# F: CryptoPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/CryptoPkg
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+# R: Xiaoyu Lu <xiaoyu1.lu@intel.com> [xiaoyuxlu]
+# R: Guomin Jiang <guomin.jiang@intel.com> [guominjia]
+/CryptoPkg/**  @xiaoyuxlu @guominjia
+
+# DynamicTablesPkg
+# F: DynamicTablesPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/DynamicTablesPkg
+# M: Sami Mujawar <Sami.Mujawar@arm.com> [samimujawar]
+# M: Alexei Fedorov <Alexei.Fedorov@arm.com> [AlexeiFedorov]
+
+# EmbeddedPkg
+# F: EmbeddedPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/EmbeddedPkg
+# M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# M: Abner Chang <abner.chang@amd.com> [changab]
+# R: Daniel Schaefer <git@danielschaefer.me> [JohnAZoidberg]
+/EmbeddedPkg/**  @JohnAZoidberg
+
+# EmulatorPkg
+# F: EmulatorPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/EmulatorPkg
+# M: Andrew Fish <afish@apple.com> [ajfish]
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# S: Maintained
+
+# EmulatorPkg: Redfish-related modules
+# F: EmulatorPkg/*Redfish*
+# M: Abner Chang <abner.chang@amd.com> [changab]
+# R: Nickle Wang <nickle@csie.io> [nicklela]
+/EmulatorPkg/**/Redfish*/**  @nicklela
+
+# FatPkg
+# F: FatPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/Edk2-fat-driver
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# T: svn - https://svn.code.sf.net/p/edk2-fatdriver2/code/trunk/EnhancedFat
+# T: git - https://github.com/tianocore/edk2-FatPkg.git
+
+# FmpDevicePkg
+# F: FmpDevicePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/FmpDevicePkg
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# R: Guomin Jiang <guomin.jiang@intel.com> [guominjia]
+# R: Wei6 Xu <wei6.xu@intel.com> [xuweiintel]
+/FmpDevicePkg/**  @guominjia @xuweiintel
+
+# IntelFsp2Pkg
+# F: IntelFsp2Pkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/IntelFsp2Pkg
+# M: Chasel Chiu <chasel.chiu@intel.com> [ChaselChiu]
+# M: Nate DeSimone <nathaniel.l.desimone@intel.com> [nate-desimone]
+# R: Star Zeng <star.zeng@intel.com> [lzeng14]
+/IntelFsp2Pkg/**  @lzeng14
+
+# IntelFsp2WrapperPkg
+# F: IntelFsp2WrapperPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/IntelFsp2WrapperPkg
+# M: Chasel Chiu <chasel.chiu@intel.com> [ChaselChiu]
+# M: Nate DeSimone <nathaniel.l.desimone@intel.com> [nate-desimone]
+# R: Star Zeng <star.zeng@intel.com> [lzeng14]
+/IntelFsp2WrapperPkg/**  @lzeng14
+
+# MdeModulePkg
+# F: MdeModulePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/MdeModulePkg
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+
+# MdeModulePkg: ACPI modules
+# F: MdeModulePkg/Include/*Acpi*.h
+# F: MdeModulePkg/Universal/Acpi/
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/MdeModulePkg/Include/*/*Acpi*.h  @LiuZhiguang001 @dandanbi @lgao4
+/MdeModulePkg/Universal/Acpi/**   @LiuZhiguang001 @dandanbi @lgao4
+
+# MdeModulePkg: ACPI modules related to S3
+# F: MdeModulePkg/*LockBox*/
+# F: MdeModulePkg/Include/*BootScript*.h
+# F: MdeModulePkg/Include/*LockBox*.h
+# F: MdeModulePkg/Include/*S3*.h
+# F: MdeModulePkg/Library/*S3*/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Eric Dong <eric.dong@intel.com> [ydong10]
+/MdeModulePkg/**/*LockBox*/**           @hwu25 @ydong10
+/MdeModulePkg/Include/*/*BootScript*.h  @hwu25 @ydong10
+/MdeModulePkg/Include/*/*LockBox*.h     @hwu25 @ydong10
+/MdeModulePkg/Include/*/*S3*.h          @hwu25 @ydong10
+/MdeModulePkg/Library/*S3*/**           @hwu25 @ydong10
+
+# MdeModulePkg: BDS modules
+# F: MdeModulePkg/*BootManager*/
+# F: MdeModulePkg/Include/Library/UefiBootManagerLib.h
+# F: MdeModulePkg/Universal/BdsDxe/
+# F: MdeModulePkg/Universal/DevicePathDxe/
+# F: MdeModulePkg/Universal/DriverHealthManagerDxe/
+# F: MdeModulePkg/Universal/LoadFileOnFv2/
+# F: MdeModulePkg/Universal/SecurityStubDxe/Defer3rdPartyImageLoad.*
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+/MdeModulePkg/**/*BootManager*/**                                 @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/Library/UefiBootManagerLib.h                @ZhichaoGao @niruiyu
+/MdeModulePkg/Universal/BdsDxe/**                                 @ZhichaoGao @niruiyu
+/MdeModulePkg/Universal/DevicePathDxe/**                          @ZhichaoGao @niruiyu
+/MdeModulePkg/Universal/DriverHealthManagerDxe/**                 @ZhichaoGao @niruiyu
+/MdeModulePkg/Universal/LoadFileOnFv2/**                          @ZhichaoGao @niruiyu
+/MdeModulePkg/Universal/SecurityStubDxe/Defer3rdPartyImageLoad.*  @ZhichaoGao @niruiyu
+
+# MdeModulePkg: Console and Graphics modules
+# F: MdeModulePkg/*Logo*/
+# F: MdeModulePkg/Include/*Logo*.h
+# F: MdeModulePkg/Include/Guid/ConnectConInEvent.h
+# F: MdeModulePkg/Include/Guid/Console*.h
+# F: MdeModulePkg/Include/Guid/StandardErrorDevice.h
+# F: MdeModulePkg/Include/Guid/TtyTerm.h
+# F: MdeModulePkg/Include/Library/BmpSupportLib.h
+# F: MdeModulePkg/Include/Library/FrameBufferBltLib.h
+# F: MdeModulePkg/Library/BaseBmpSupportLib/
+# F: MdeModulePkg/Library/FrameBufferBltLib/
+# F: MdeModulePkg/Universal/Console/
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+/MdeModulePkg/**/*Logo*/**                         @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/*/*Logo*.h                   @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/Guid/ConnectConInEvent.h     @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/Guid/Console*.h              @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/Guid/StandardErrorDevice.h   @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/Guid/TtyTerm.h               @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/Library/BmpSupportLib.h      @ZhichaoGao @niruiyu
+/MdeModulePkg/Include/Library/FrameBufferBltLib.h  @ZhichaoGao @niruiyu
+/MdeModulePkg/Library/BaseBmpSupportLib/**         @ZhichaoGao @niruiyu
+/MdeModulePkg/Library/FrameBufferBltLib/**         @ZhichaoGao @niruiyu
+/MdeModulePkg/Universal/Console/**                 @ZhichaoGao @niruiyu
+
+# MdeModulePkg: Core services (PEI, DXE and Runtime) modules
+# F: MdeModulePkg/*Mem*/
+# F: MdeModulePkg/*SectionExtract*/
+# F: MdeModulePkg/*StatusCode*/
+# F: MdeModulePkg/Application/DumpDynPcd/
+# F: MdeModulePkg/Core/Dxe/
+# F: MdeModulePkg/Core/DxeIplPeim/
+# F: MdeModulePkg/Core/RuntimeDxe/
+# F: MdeModulePkg/Include/*Mem*.h
+# F: MdeModulePkg/Include/*Pcd*.h
+# F: MdeModulePkg/Include/*Perf*.h
+# F: MdeModulePkg/Include/*StatusCode*.h
+# F: MdeModulePkg/Include/Guid/Crc32GuidedSectionExtraction.h
+# F: MdeModulePkg/Include/Guid/EventExitBootServiceFailed.h
+# F: MdeModulePkg/Include/Guid/IdleLoopEvent.h
+# F: MdeModulePkg/Include/Guid/LoadModuleAtFixedAddress.h
+# F: MdeModulePkg/Include/Guid/LzmaDecompress.h
+# F: MdeModulePkg/Include/Library/SecurityManagementLib.h
+# F: MdeModulePkg/Library/*Decompress*/
+# F: MdeModulePkg/Library/*Perf*/
+# F: MdeModulePkg/Library/DxeSecurityManagementLib/
+# F: MdeModulePkg/Universal/PCD/
+# F: MdeModulePkg/Universal/PlatformDriOverrideDxe/
+# F: MdeModulePkg/Universal/SecurityStubDxe/SecurityStub.c
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/MdeModulePkg/**/*Mem*/**                                  @dandanbi  @lgao4
+/MdeModulePkg/**/*SectionExtract*/**                       @dandanbi  @lgao4
+/MdeModulePkg/**/*StatusCode*/**                           @dandanbi  @lgao4
+/MdeModulePkg/Application/DumpDynPcd/**                    @dandanbi  @lgao4
+/MdeModulePkg/Core/Dxe/**                                  @dandanbi  @lgao4
+/MdeModulePkg/Core/DxeIplPeim/**                           @dandanbi  @lgao4
+/MdeModulePkg/Core/DxeIplPeim/**/RiscV64/**                @dandanbi  @lgao4 @JohnAZoidberg
+/MdeModulePkg/Core/RuntimeDxe/**                           @dandanbi  @lgao4
+/MdeModulePkg/Include/*/*Mem*.h                            @dandanbi  @lgao4
+/MdeModulePkg/Include/*/*Pcd*.h                            @dandanbi  @lgao4
+/MdeModulePkg/Include/*/*Perf*.h                           @dandanbi  @lgao4
+/MdeModulePkg/Include/*/*StatusCode*.h                     @dandanbi  @lgao4
+/MdeModulePkg/Include/Guid/Crc32GuidedSectionExtraction.h  @dandanbi  @lgao4
+/MdeModulePkg/Include/Guid/EventExitBootServiceFailed.h    @dandanbi  @lgao4
+/MdeModulePkg/Include/Guid/IdleLoopEvent.h                 @dandanbi  @lgao4
+/MdeModulePkg/Include/Guid/LoadModuleAtFixedAddress.h      @dandanbi  @lgao4
+/MdeModulePkg/Include/Guid/LzmaDecompress.h                @dandanbi  @lgao4
+/MdeModulePkg/Include/Library/SecurityManagementLib.h      @dandanbi  @lgao4
+/MdeModulePkg/Library/*Decompress*/**                      @dandanbi  @lgao4
+/MdeModulePkg/Library/*Perf*/**                            @dandanbi  @lgao4
+/MdeModulePkg/Library/DxeSecurityManagementLib/**          @dandanbi  @lgao4
+/MdeModulePkg/Universal/PCD/**                             @dandanbi  @lgao4
+/MdeModulePkg/Universal/PlatformDriOverrideDxe/**          @dandanbi  @lgao4
+/MdeModulePkg/Universal/SecurityStubDxe/SecurityStub.c     @dandanbi  @lgao4
+
+# MdeModulePkg: Device and Peripheral modules
+# F: MdeModulePkg/*PciHostBridge*/
+# F: MdeModulePkg/Bus/
+# F: MdeModulePkg/Include/*Ata*.h
+# F: MdeModulePkg/Include/*IoMmu*.h
+# F: MdeModulePkg/Include/*NonDiscoverableDevice*.h
+# F: MdeModulePkg/Include/*NvmExpress*.h
+# F: MdeModulePkg/Include/*SdMmc*.h
+# F: MdeModulePkg/Include/*Ufs*.h
+# F: MdeModulePkg/Include/*Usb*.h
+# F: MdeModulePkg/Include/Guid/RecoveryDevice.h
+# F: MdeModulePkg/Include/Guid/S3StorageDeviceInitList.h
+# F: MdeModulePkg/Include/Library/PciHostBridgeLib.h
+# F: MdeModulePkg/Include/Ppi/StorageSecurityCommand.h
+# F: MdeModulePkg/Include/Protocol/Ps2Policy.h
+# F: MdeModulePkg/Library/NonDiscoverableDeviceRegistrationLib/
+# F: MdeModulePkg/Universal/PcatSingleSegmentPciCfg2Pei/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+/MdeModulePkg/**/*PciHostBridge*/**                            @hwu25  @niruiyu
+/MdeModulePkg/Bus/**                                           @hwu25  @niruiyu
+/MdeModulePkg/Include/*/*Ata*.h                                @hwu25  @niruiyu
+/MdeModulePkg/Include/*/*IoMmu*.h                              @hwu25  @niruiyu
+/MdeModulePkg/Include/*/*NonDiscoverableDevice*.h              @hwu25  @niruiyu
+/MdeModulePkg/Include/*/*NvmExpress*.h                         @hwu25  @niruiyu
+/MdeModulePkg/Include/*/*SdMmc*.h                              @hwu25  @niruiyu
+/MdeModulePkg/Include/*/*Ufs*.h                                @hwu25  @niruiyu
+/MdeModulePkg/Include/*/*Usb*.h                                @hwu25  @niruiyu
+/MdeModulePkg/Include/Guid/RecoveryDevice.h                    @hwu25  @niruiyu
+/MdeModulePkg/Include/Guid/S3StorageDeviceInitList.h           @hwu25  @niruiyu @ydong10
+/MdeModulePkg/Include/Library/PciHostBridgeLib.h               @hwu25  @niruiyu
+/MdeModulePkg/Include/Ppi/StorageSecurityCommand.h             @hwu25  @niruiyu
+/MdeModulePkg/Include/Protocol/Ps2Policy.h                     @hwu25  @niruiyu
+/MdeModulePkg/Library/NonDiscoverableDeviceRegistrationLib/**  @hwu25  @niruiyu
+/MdeModulePkg/Universal/PcatSingleSegmentPciCfg2Pei/**         @hwu25  @niruiyu
+
+# MdeModulePkg: Disk modules
+# F: MdeModulePkg/Universal/Disk/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+/MdeModulePkg/Universal/Disk/**  @hwu25  @niruiyu  @ZhichaoGao
+
+# MdeModulePkg: Firmware Update modules
+# F: MdeModulePkg/*Capsule*/
+# F: MdeModulePkg/Include/*Capsule*.h
+# F: MdeModulePkg/Include/Library/DisplayUpdateProgressLib.h
+# F: MdeModulePkg/Include/Library/FmpAuthenticationLib.h
+# F: MdeModulePkg/Include/Protocol/EsrtManagement.h
+# F: MdeModulePkg/Include/Protocol/FirmwareManagementProgress.h
+# F: MdeModulePkg/Library/DisplayUpdateProgressLib*/
+# F: MdeModulePkg/Library/FmpAuthenticationLibNull/
+# F: MdeModulePkg/Universal/Esrt*/
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Guomin Jiang <guomin.jiang@intel.com> [guominjia]
+/MdeModulePkg/**/*Capsule*/**                                @lgao4  @guominjia
+/MdeModulePkg/Include/*/*Capsule*.h                          @lgao4  @guominjia
+/MdeModulePkg/Include/Library/DisplayUpdateProgressLib.h     @lgao4  @guominjia
+/MdeModulePkg/Include/Library/FmpAuthenticationLib.h         @lgao4  @guominjia
+/MdeModulePkg/Include/Protocol/EsrtManagement.h              @lgao4  @guominjia
+/MdeModulePkg/Include/Protocol/FirmwareManagementProgress.h  @lgao4  @guominjia
+/MdeModulePkg/Library/DisplayUpdateProgressLib*/**           @lgao4  @guominjia
+/MdeModulePkg/Library/FmpAuthenticationLibNull/**            @lgao4  @guominjia
+/MdeModulePkg/Universal/Esrt*/**                             @lgao4  @guominjia
+
+# MdeModulePkg: HII and UI modules
+# F: MdeModulePkg/*FileExplorer*/
+# F: MdeModulePkg/*Hii*/
+# F: MdeModulePkg/*Ui*/
+# F: MdeModulePkg/Application/BootManagerMenuApp/
+# F: MdeModulePkg/Include/*FileExplorer*.h
+# F: MdeModulePkg/Include/*FormBrowser*.h
+# F: MdeModulePkg/Include/*Hii*.h
+# F: MdeModulePkg/Include/Library/CustomizedDisplayLib.h
+# F: MdeModulePkg/Include/Protocol/DisplayProtocol.h
+# F: MdeModulePkg/Library/CustomizedDisplayLib/
+# F: MdeModulePkg/Universal/DisplayEngineDxe/
+# F: MdeModulePkg/Universal/DriverSampleDxe/
+# F: MdeModulePkg/Universal/SetupBrowserDxe/
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Eric Dong <eric.dong@intel.com> [ydong10]
+/MdeModulePkg/**/*FileExplorer*/**                    @dandanbi  @ydong10
+/MdeModulePkg/**/*Hii*/**                             @dandanbi  @ydong10
+/MdeModulePkg/**/*Ui*/**                              @dandanbi  @ydong10
+/MdeModulePkg/Application/BootManagerMenuApp/**       @ZhichaoGao @niruiyu @dandanbi  @ydong10
+/MdeModulePkg/Include/*/*FileExplorer*.h              @dandanbi  @ydong10
+/MdeModulePkg/Include/*/*FormBrowser*.h               @dandanbi  @ydong10
+/MdeModulePkg/Include/*/*Hii*.h                       @dandanbi  @ydong10
+/MdeModulePkg/Include/Library/CustomizedDisplayLib.h  @dandanbi  @ydong10
+/MdeModulePkg/Include/Protocol/DisplayProtocol.h      @dandanbi  @ydong10
+/MdeModulePkg/Library/CustomizedDisplayLib/**         @dandanbi  @ydong10
+/MdeModulePkg/Universal/DisplayEngineDxe/**           @dandanbi  @ydong10
+/MdeModulePkg/Universal/DriverSampleDxe/**            @dandanbi  @ydong10
+/MdeModulePkg/Universal/SetupBrowserDxe/**            @dandanbi  @ydong10
+
+# MdeModulePkg: Management Mode (MM, SMM) modules
+# F: MdeModulePkg/*Smi*/
+# F: MdeModulePkg/*Smm*/
+# F: MdeModulePkg/Include/*Smi*.h
+# F: MdeModulePkg/Include/*Smm*.h
+# R: Eric Dong <eric.dong@intel.com> [ydong10]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+/MdeModulePkg/**/*Smi*/**        @ydong10  @niruiyu
+/MdeModulePkg/**/*Smm*/**        @ydong10  @niruiyu
+/MdeModulePkg/Include/*/*Smi*.h  @ydong10  @niruiyu
+/MdeModulePkg/Include/*/*Smm*.h  @ydong10  @niruiyu
+
+# MdeModulePkg: Reset modules
+# F: MdeModulePkg/*Reset*/
+# F: MdeModulePkg/Include/*Reset*.h
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+/MdeModulePkg/**/*Reset*/          @ZhichaoGao  @niruiyu
+/MdeModulePkg/Include/*/*Reset*.h  @ZhichaoGao  @niruiyu
+
+# MdeModulePkg: Pei Core
+# F: MdeModulePkg/Core/Pei/
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Debkumar De <debkumar.de@intel.com>
+# R: Catharine West <catharine.west@intel.com> [catharine-intl]
+/MdeModulePkg/Core/Pei/**          @dandanbi @lgao4 @dde01 @catharine-intl
+/MdeModulePkg/Core/Pei/*Reset*/**  @dandanbi @lgao4 @dde01 @catharine-intl @ZhichaoGao @niruiyu
+
+# MdeModulePkg: Serial modules
+# F: MdeModulePkg/*Serial*/
+# F: MdeModulePkg/Include/*SerialPort*.h
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+/MdeModulePkg/**/*Serial*/**            @niruiyu  @ZhichaoGao
+/MdeModulePkg/Include/*/*SerialPort*.h  @niruiyu  @ZhichaoGao
+
+# MdeModulePkg: SMBIOS modules
+# F: MdeModulePkg/Universal/Smbios*/
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+# R: Dandan Bi <dandan.bi@intel.com> [dandanbi]
+# R: Star Zeng <star.zeng@intel.com> [lzeng14]
+# R: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+/MdeModulePkg/Universal/Smbios*/**  @LiuZhiguang001 @dandanbi  @lzeng14  @ZhichaoGao
+
+# MdeModulePkg: UEFI Variable modules
+# F: MdeModulePkg/*Var*/
+# F: MdeModulePkg/Include/*/*FaultTolerantWrite*.h
+# F: MdeModulePkg/Include/*/*Var*.h
+# F: MdeModulePkg/Include/Guid/SystemNvDataGuid.h
+# F: MdeModulePkg/Include/Protocol/SwapAddressRange.h
+# F: MdeModulePkg/Universal/FaultTolerantWrite*/
+# R: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+# R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+/MdeModulePkg/**/*Var*/**                          @hwu25  @lgao4
+/MdeModulePkg/Include/*/*FaultTolerantWrite*.h     @hwu25  @lgao4
+/MdeModulePkg/Include/*/*Var*.h                    @hwu25  @lgao4
+/MdeModulePkg/Include/Guid/SystemNvDataGuid.h      @hwu25  @lgao4
+/MdeModulePkg/Include/Protocol/SwapAddressRange.h  @hwu25  @lgao4
+/MdeModulePkg/Universal/FaultTolerantWrite*/**     @hwu25  @lgao4
+
+# MdeModulePkg: Universal Payload definitions
+# F: MdeModulePkg/Include/UniversalPayload/
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+# R: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Gua Guo <gua.guo@intel.com> [gguo11837463]
+/MdeModulePkg/Include/UniversalPayload/**              @LiuZhiguang001 @niruiyu @gguo11837463
+/MdeModulePkg/Include/UniversalPayload/*SerialPort*.h  @LiuZhiguang001 @niruiyu @gguo11837463 @ZhichaoGao
+/MdeModulePkg/Include/UniversalPayload/*Acpi*.h        @LiuZhiguang001 @niruiyu @gguo11837463 @dandanbi @lgao4
+
+
+
+###
+### Extra rules
+###
+
+/MdeModulePkg/**/*BootManagerUi*/**                 @dandanbi @ydong10 @ZhichaoGao @niruiyu
+/MdeModulePkg/**/VarCheckHiiLib/**                  @hwu25 @lgao4 @dandanbi @ydong10
+/MdeModulePkg/Bus/**/*Serial*/**                    @niruiyu  @ZhichaoGao @hwu25
+/MdeModulePkg/**/*Smm*LockBox*/**                   @hwu25 @ydong10 @niruiyu
+/MdeModulePkg/**/*StatusCode*/Smm/**                @dandanbi @lgao4 @niruiyu @ydong10
+/MdeModulePkg/**/*Smm*StatusCode*/**                @dandanbi @lgao4 @niruiyu @ydong10
+/MdeModulePkg/**/*Smm*Perf*/**                      @dandanbi @lgao4 @niruiyu @ydong10
+/MdeModulePkg/**/*Perf*Smm*/**                      @LiuZhiguang001 @dandanbi @lgao4 @niruiyu @ydong10
+/MdeModulePkg/**/Acpi/*Smm*/**                      @LiuZhiguang001 @dandanbi @lgao4 @niruiyu @ydong10
+/MdeModulePkg/**/*Smm*Mem*/**                       @dandanbi @lgao4 @niruiyu @ydong10
+
+/MdeModulePkg/Include/*/*Smm*LockBox*.h             @hwu25 @ydong10 @niruiyu
+/MdeModulePkg/Include/*/*Smm*Mem*.h                 @dandanbi @lgao4 @niruiyu @ydong10
+/MdeModulePkg/Include/*/*Acpi*S3*.h                 @LiuZhiguang001 @dandanbi @hwu25 @lgao4 @ydong10
+/MdeModulePkg/Include/*/*S3*Smm*.h                  @hwu25 @niruiyu @ydong10
+/MdeModulePkg/Include/*/*Smm*FaultTolerantWrite*.h  @hwu25  @lgao4 @niruiyu @ydong10
+/MdeModulePkg/Include/*/*Smm*Var*.h                 @hwu25  @lgao4 @niruiyu @ydong10
+/MdeModulePkg/Include/*/*StatusCode*Var*.h          @dandanbi @hwu25  @lgao4
+/MdeModulePkg/Include/*/*BootScript*Var*.h          @hwu25 @lgao4 @ydong10
+
+
+# MdePkg
+# F: MdePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/MdePkg
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# M: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
+# R: Zhiguang Liu <zhiguang.liu@intel.com> [LiuZhiguang001]
+/MdePkg/**             @LiuZhiguang001
+/MdePkg/**/RiscV64/**  @LiuZhiguang001 @JohnAZoidberg
+
+# NetworkPkg
+# F: NetworkPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/NetworkPkg
+# M: Maciej Rabeda <maciej.rabeda@linux.intel.com> [mrabeda]
+# R: Jiaxin Wu <jiaxin.wu@intel.com> [jiaxinwu]
+# R: Siyuan Fu <siyuan.fu@intel.com> [sfu5]
+/NetworkPkg/**  @jiaxinwu @sfu5
+
+# OvmfPkg
+# F: OvmfPkg/
+# W: http://www.tianocore.org/ovmf/
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# R: Jordan Justen <jordan.l.justen@intel.com> [jljusten]
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+# S: Maintained
+/OvmfPkg/**   @jljusten @kraxel
+
+# OvmfPkg: bhyve-related modules
+# F: OvmfPkg/Bhyve/
+# F: OvmfPkg/Include/IndustryStandard/Bhyve.h
+# F: OvmfPkg/Include/Library/BhyveFwCtlLib.h
+# F: OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.c
+# F: OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.inf
+# F: OvmfPkg/Library/BhyveFwCtlLib/
+# F: OvmfPkg/Library/PciHostBridgeLibScan/
+# F: OvmfPkg/Library/PlatformBootManagerLibBhyve/
+# F: OvmfPkg/Library/ResetSystemLib/BaseResetShutdownBhyve.c
+# F: OvmfPkg/Library/ResetSystemLib/BaseResetSystemLibBhyve.inf
+# R: Rebecca Cran <rebecca@bsdio.com> [bcran]
+# R: Peter Grehan <grehan@freebsd.org> [grehan-freebsd]
+/OvmfPkg/Bhyve/**                                            @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Include/IndustryStandard/Bhyve.h                    @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Include/Library/BhyveFwCtlLib.h                     @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.c        @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Library/AcpiTimerLib/BaseAcpiTimerLibBhyve.inf      @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Library/BhyveFwCtlLib/**                            @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Library/PlatformBootManagerLibBhyve/**              @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Library/ResetSystemLib/BaseResetShutdownBhyve.c     @jljusten @kraxel @bcran @grehan-freebsd
+/OvmfPkg/Library/ResetSystemLib/BaseResetSystemLibBhyve.inf  @jljusten @kraxel @bcran @grehan-freebsd
+
+# OvmfPkg: cloudhv-related modules
+# F: OvmfPkg/CloudHv/
+# F: OvmfPkg/Include/IndustryStandard/CloudHv.h
+# R: Sebastien Boeuf <sebastien.boeuf@intel.com> [sboeuf]
+/OvmfPkg/CloudHv/**                          @jljusten @kraxel @sboeuf
+/OvmfPkg/Include/IndustryStandard/CloudHv.h  @jljusten @kraxel @sboeuf
+
+# OvmfPkg: microvm-related modules
+# F: OvmfPkg/Microvm/
+# F: OvmfPkg/Include/IndustryStandard/Microvm.h
+# F: OvmfPkg/Library/ResetSystemLib/*Microvm.*
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+/OvmfPkg/Microvm/**                          @jljusten @kraxel
+/OvmfPkg/Include/IndustryStandard/Microvm.h  @jljusten @kraxel
+/OvmfPkg/Library/ResetSystemLib/*Microvm.*   @jljusten @kraxel
+
+# OvmfPkg: CSM modules
+# F: OvmfPkg/Csm/
+# R: David Woodhouse <dwmw2@infradead.org> [dwmw2]
+/OvmfPkg/Csm/**  @jljusten @kraxel @dwmw2
+
+# OvmfPkg: Confidential Computing
+# F: OvmfPkg/AmdSev/
+# F: OvmfPkg/AmdSevDxe/
+# F: OvmfPkg/Include/Guid/ConfidentialComputingSecret.h
+# F: OvmfPkg/Include/Library/MemEncryptSevLib.h
+# F: OvmfPkg/IoMmuDxe/AmdSevIoMmu.*
+# F: OvmfPkg/Library/BaseMemEncryptSevLib/
+# F: OvmfPkg/Library/PlatformBootManagerLibGrub/
+# F: OvmfPkg/Library/VmgExitLib/
+# F: OvmfPkg/PlatformPei/AmdSev.c
+# F: OvmfPkg/ResetVector/
+# F: OvmfPkg/Sec/
+# R: Brijesh Singh <brijesh.singh@amd.com> [codomania]
+# R: Erdem Aktas <erdemaktas@google.com> [ruleof2]
+# R: James Bottomley <jejb@linux.ibm.com> [jejb]
+# R: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# R: Min Xu <min.m.xu@intel.com> [mxu9]
+# R: Tom Lendacky <thomas.lendacky@amd.com> [tlendacky]
+/OvmfPkg/AmdSev/**                                   @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/AmdSevDxe/**                                @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/Include/Guid/ConfidentialComputingSecret.h  @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/Include/Library/MemEncryptSevLib.h          @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/IoMmuDxe/AmdSevIoMmu.*                      @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/Library/BaseMemEncryptSevLib/**             @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/Library/PlatformBootManagerLibGrub/**       @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/Library/VmgExitLib/**                       @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/PlatformPei/AmdSev.c                        @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/ResetVector/**                              @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+/OvmfPkg/Sec/**                                      @jljusten @kraxel @codomania @ruleof2 @jejb @jyao1 @mxu9 @tlendacky
+
+# OvmfPkg: FDT related modules
+# F: OvmfPkg/Fdt
+# R: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+# R: Gerd Hoffmann <kraxel@redhat.com> [kraxel]
+# R: Abner Chang <abner.chang@amd.com> [changab]
+/OvmfPkg/Fdt/**  @jljusten @kraxel @leiflindholm @changab
+
+# OvmfPkg: LsiScsi driver
+# F: OvmfPkg/LsiScsiDxe/
+# R: Gary Lin <gary.lin@hpe.com> [lcp]
+/OvmfPkg/LsiScsiDxe/**   @jljusten @kraxel @lcp
+
+# OvmfPkg: TCG- and TPM2-related modules
+# F: OvmfPkg/Include/IndustryStandard/QemuTpm.h
+# F: OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+# F: OvmfPkg/Library/Tcg2PhysicalPresenceLib*/
+# F: OvmfPkg/PlatformPei/ClearCache.c
+# F: OvmfPkg/Tcg/
+# R: Marc-André Lureau <marcandre.lureau@redhat.com> [elmarco]
+# R: Stefan Berger <stefanb@linux.ibm.com> [stefanberger]
+/OvmfPkg/Include/IndustryStandard/QemuTpm.h            @jljusten @kraxel @elmarco @stefanberger
+/OvmfPkg/Library/Tcg2PhysicalPresenceLib*/**           @jljusten @kraxel @elmarco @stefanberger
+/OvmfPkg/PlatformPei/ClearCache.c                      @jljusten @kraxel @elmarco @stefanberger
+/OvmfPkg/Tcg/**                                        @jljusten @kraxel @elmarco @stefanberger
+
+# OvmfPkg: Xen-related modules
+# F: OvmfPkg/Include/Guid/XenBusRootDevice.h
+# F: OvmfPkg/Include/Guid/XenInfo.h
+# F: OvmfPkg/Include/IndustryStandard/Xen/
+# F: OvmfPkg/Include/Library/XenHypercallLib.h
+# F: OvmfPkg/Include/Library/XenIoMmioLib.h
+# F: OvmfPkg/Include/Library/XenPlatformLib.h
+# F: OvmfPkg/Include/Protocol/XenBus.h
+# F: OvmfPkg/Include/Protocol/XenIo.h
+# F: OvmfPkg/Library/PciHostBridgeLibScan/
+# F: OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+# F: OvmfPkg/Library/XenConsoleSerialPortLib/
+# F: OvmfPkg/Library/XenHypercallLib/
+# F: OvmfPkg/Library/XenIoMmioLib/
+# F: OvmfPkg/Library/XenPlatformLib/
+# F: OvmfPkg/Library/XenRealTimeClockLib/
+# F: OvmfPkg/OvmfXen.*
+# F: OvmfPkg/OvmfXenElfHeaderGenerator.c
+# F: OvmfPkg/SmbiosPlatformDxe/*Xen*
+# F: OvmfPkg/XenAcpiPlatformDxe/
+# F: OvmfPkg/XenBusDxe/
+# F: OvmfPkg/XenIoPciDxe/
+# F: OvmfPkg/XenIoPvhDxe/
+# F: OvmfPkg/XenPlatformPei/
+# F: OvmfPkg/XenPvBlkDxe/
+# F: OvmfPkg/XenResetVector/
+# R: Anthony Perard <anthony.perard@citrix.com> [sheep]
+# R: Julien Grall <julien@xen.org> [jgrall]
+/OvmfPkg/Include/Guid/XenBusRootDevice.h               @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Include/Guid/XenInfo.h                        @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Include/IndustryStandard/Xen/**               @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Include/Library/XenHypercallLib.h             @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Include/Library/XenIoMmioLib.h                @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Include/Library/XenPlatformLib.h              @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Include/Protocol/XenBus.h                     @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Include/Protocol/XenIo.h                      @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Library/XenConsoleSerialPortLib/**            @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Library/XenHypercallLib/**                    @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Library/XenIoMmioLib/**                       @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Library/XenPlatformLib/**                     @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/Library/XenRealTimeClockLib/**                @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/OvmfXen.*                                     @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/OvmfXenElfHeaderGenerator.c                   @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/SmbiosPlatformDxe/*Xen*                       @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/XenAcpiPlatformDxe/**                         @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/XenBusDxe/**                                  @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/XenIoPciDxe/**                                @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/XenIoPvhDxe/**                                @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/XenPlatformPei/**                             @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/XenPvBlkDxe/**                                @jljusten @kraxel @sheep @jgrall
+/OvmfPkg/XenResetVector/**                             @jljusten @kraxel @sheep @jgrall
+#
+# ATTENTION: The following component does not exist anymore
+#
+#/OvmfPkg/XenTimerDxe/**                                @jljusten @kraxel @sheep julien@xen.org
+
+# Files common to Bhyve and Xen
+/OvmfPkg/Library/PciHostBridgeLibScan/**               @jljusten @kraxel @bcran @grehan-freebsd @sheep @jgrall
+
+# Files common to TCG and XEN
+/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c  @jljusten @kraxel @elmarco @stefanberger @sheep @jgrall
+
+# PcAtChipsetPkg
+# F: PcAtChipsetPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/PcAtChipsetPkg
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+
+# PrmPkg
+# F: PrmPkg/
+# M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
+# M: Nate DeSimone <nathaniel.l.desimone@intel.com> [nate-desimone]
+
+# PrmPkg: ACPI related modules
+# R: Ankit Sinha <ankit.sinha@intel.com> [ankit13s]
+
+# RedfishPkg: Redfish related modules
+# F: RedfishPkg/
+# M: Abner Chang <abner.chang@amd.com> [changab]
+# R: Nickle Wang <nickle@csie.io> [nicklela]
+/RedfishPkg/**  @nicklela
+
+# SecurityPkg
+# F: SecurityPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/SecurityPkg
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+
+# SecurityPkg: Secure boot related modules
+# F: SecurityPkg/Library/DxeImageVerificationLib/
+# F: SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/
+# F: SecurityPkg/Library/AuthVariableLib/
+# R: Min Xu <min.m.xu@intel.com> [mxu9]
+/SecurityPkg/Library/DxeImageVerificationLib/**            @mxu9
+/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/**  @mxu9
+/SecurityPkg/Library/AuthVariableLib/**                    @mxu9
+
+# SecurityPkg: Tcg related modules
+# F: SecurityPkg/Tcg/
+# R: Qi Zhang <qi1.zhang@intel.com> [qizhangz]
+# R: Rahul Kumar <rahul1.kumar@intel.com> [rahul1-kumar]
+/SecurityPkg/Tcg/** @qizhangz @rahul1-kumar
+
+# ShellPkg
+# F: ShellPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/ShellPkg
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# M: Zhichao Gao <zhichao.gao@intel.com> [ZhichaoGao]
+
+# SignedCapsulePkg
+# F: SignedCapsulePkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/SignedCapsulePkg
+# M: Jian J Wang <jian.j.wang@intel.com> [jwang36]
+
+# SourceLevelDebugPkg
+# F: SourceLevelDebugPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/SourceLevelDebugPkg
+# M: Hao A Wu <hao.a.wu@intel.com> [hwu25]
+
+# StandaloneMmPkg
+# F: StandaloneMmPkg/
+# M: Ard Biesheuvel <ardb+tianocore@kernel.org> [ardbiesheuvel]
+# M: Sami Mujawar <sami.mujawar@arm.com> [samimujawar]
+# M: Jiewen Yao <jiewen.yao@intel.com> [jyao1]
+# R: Supreeth Venkatesh <supreeth.venkatesh@arm.com> [supven01]
+/StandaloneMmPkg/**  @supven01
+
+# UefiCpuPkg
+# F: UefiCpuPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/UefiCpuPkg
+# M: Eric Dong <eric.dong@intel.com> [ydong10]
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# R: Rahul Kumar <rahul1.kumar@intel.com> [rahul1-kumar]
+/UefiCpuPkg/**  @rahul1-kumar
+
+# UefiCpuPkg: Sec related modules
+# F: UefiCpuPkg/SecCore/
+# F: UefiCpuPkg/ResetVector/
+# R: Debkumar De <debkumar.de@intel.com> [dde01]
+# R: Catharine West <catharine.west@intel.com> [catharine-intl]
+/UefiCpuPkg/SecCore/**      @rahul1-kumar @dde01 @catharine-intl
+/UefiCpuPkg/ResetVector/**  @rahul1-kumar @dde01 @catharine-intl
+
+# UefiPayloadPkg
+# F: UefiPayloadPkg/
+# W: https://github.com/tianocore/tianocore.github.io/wiki/UefiPayloadPkg
+# M: Guo Dong <guo.dong@intel.com> [gdong1]
+# M: Ray Ni <ray.ni@intel.com> [niruiyu]
+# M: Sean Rhodes <sean@starlabs.systems> [Sean-StarLabs]
+# M: James Lu <james.lu@intel.com> [jameslu8]
+# R: Gua Guo <gua.guo@intel.com> [gguo11837463]
+# S: Maintained
+/UefiPalyloadPkg/**  @gguo11837463
+
+# UnitTestFrameworkPkg
+# F: UnitTestFrameworkPkg/
+# M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+# M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
+# R: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
+# R: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
+# S: Maintained
+/UnitTestFrameworkPkg/**  @spbrogan @corthon
+

--- a/.github/workflows/AssignReviewers.yml
+++ b/.github/workflows/AssignReviewers.yml
@@ -1,0 +1,27 @@
+## @file
+# Assign reviewers from a REVIEWERS file using CODEOWNERS syntax
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+name: Assign reviewers from a REVIEWERS file using CODEOWNERS syntax
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
+
+jobs:
+  assign_reviewers:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout Pull Request Target
+        uses: actions/checkout@v2
+      - uses: mdkinney/github-action-assign-reviewers@main
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/CheckCodeOwnerFiles.yml
+++ b/.github/workflows/CheckCodeOwnerFiles.yml
@@ -1,0 +1,39 @@
+## @file
+# Check CODEOWNERS coverage of all files in PR
+#
+# Only run this check if one or more files modified in the PR
+# are not CODEOWNERS, REVIEWERS, or Maintainers.txt.
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+name: Check CODEOWNERS coverage of all files in PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
+    paths-ignore:
+      - 'CODEOWNERS'
+      - 'docs/CODEOWNERS'
+      - '.github/CODEOWNERS'
+      - 'REVIEWERS'
+      - 'docs/REVIEWERS'
+      - '.github/REVIEWERS'
+      - 'Maintainers.txt'
+
+jobs:
+  codeowners_files_validator:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v2
+      - name: CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files"
+          experimental_checks: "notowned"
+          github_access_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/CheckCodeOwnerMaintainers.yml
+++ b/.github/workflows/CheckCodeOwnerMaintainers.yml
@@ -1,0 +1,121 @@
+## @file
+# Check CODEOWNERS, REVIEWERS, and Maintainers.txt files.
+#
+# Only run this check if any of the files modified in the PR
+# are CODEOWNERS, REVIEWERS, or Maintainers.txt.
+#
+# This workflow uses pull_request_target to support passing in
+# github_access_token that is not available for pull_request.
+# The checkout action checks out the head of the PR.  In this
+# specific workflow, this is safe because there are no dependencies
+# on any files other that this .yml file and known external actions.
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+name: Check CODEOWNERS, REVIEWERS, and Maintainers.txt files
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
+    paths:
+      - 'CODEOWNERS'
+      - 'docs/CODEOWNERS'
+      - '.github/CODEOWNERS'
+      - 'REVIEWERS'
+      - 'docs/REVIEWERS'
+      - '.github/REVIEWERS'
+      - 'Maintainers.txt'
+
+jobs:
+  check_codeowners_maintainers:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Check CODEOWNERS, REVIEWERS, and Maintainers.txt files
+        uses: mdkinney/github-action-check-codeowners-maintainers@main
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+
+  codeowners_validator_user:
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.user.type == 'User'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files,duppatterns,syntax"
+          experimental_checks: "notowned,avoid-shadowing"
+          github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+
+  codeowners_validator_organization:
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.user.type == 'Organization'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files,owners,duppatterns,syntax"
+          experimental_checks: "notowned,avoid-shadowing"
+          github_access_token: "${{ secrets.CODEOWNERS_VALIDATOR_TOKEN }}"
+
+  reviewers_validator_user:
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.user.type == 'User'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Copy REVIEWERS to CODEOWNERS
+        run: |
+          [[ -e CODEOWNERS ]]         && rm CODEOWNERS
+          [[ -e docs/CODEOWNERS ]]    && rm docs/CODEOWNERS
+          [[ -e .github/CODEOWNERS ]] && rm .github/CODEOWNERS
+          [[ -e REVIEWERS ]]          && cp REVIEWERS CODEOWNERS
+          [[ -e docs/REVIEWERS ]]     && cp docs/REVIEWERS docs/CODEOWNERS
+          [[ -e .github/REVIEWERS ]]  && cp .github/REVIEWERS .github/CODEOWNERS
+      - name: REVIEWERS Validator
+        uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files,duppatterns,syntax"
+          experimental_checks: "avoid-shadowing"
+          github_access_token: "${{ secrets.GITHUB_TOKEN }}"
+
+  reviewers_validator_organization:
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.user.type == 'Organization'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Copy REVIEWERS to CODEOWNERS
+        run: |
+          [[ -e CODEOWNERS ]]         && rm CODEOWNERS
+          [[ -e docs/CODEOWNERS ]]    && rm docs/CODEOWNERS
+          [[ -e .github/CODEOWNERS ]] && rm .github/CODEOWNERS
+          [[ -e REVIEWERS ]]          && cp REVIEWERS CODEOWNERS
+          [[ -e docs/REVIEWERS ]]     && cp docs/REVIEWERS docs/CODEOWNERS
+          [[ -e .github/REVIEWERS ]]  && cp .github/REVIEWERS .github/CODEOWNERS
+      - name: REVIEWERS Validator
+        uses: mszostok/codeowners-validator@v0.7.4
+        with:
+          checks: "files,owners,duppatterns,syntax"
+          experimental_checks: "avoid-shadowing"
+          github_access_token: "${{ secrets.CODEOWNERS_VALIDATOR_TOKEN }}"

--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -367,7 +367,9 @@ class GitDiffCheck:
                     self.filename.startswith('BaseTools/BinWrappers/PosixLike/') or \
                     self.filename.startswith('BaseTools/BinPipWrappers/PosixLike/') or \
                     self.filename.startswith('BaseTools/Bin/CYGWIN_NT-5.1-i686/') or \
-                    self.filename == 'BaseTools/BuildEnv':
+                    self.filename == 'BaseTools/BuildEnv' or \
+                    self.filename.endswith('CODEOWNERS') or \
+                    self.filename.endswith('REVIEWERS'):
                     #
                     # Do not enforce CR/LF line endings for linux shell scripts.
                     # Some linux shell scripts don't end with the ".sh" extension,


### PR DESCRIPTION
Add CODEOWNERS and REVIEWRS based on Maintainers.txt along with github actions to assign reviewers to a PR and verify that any updates to CODEOWNERS, REVIEWERS or Maintainers.txt are in sync.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>