### PR TITLE
BaseTools/Scripts: PatchCheck support CODEOWNERS locations

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -368,8 +368,8 @@ class GitDiffCheck:
                     self.filename.startswith('BaseTools/BinPipWrappers/PosixLike/') or \
                     self.filename.startswith('BaseTools/Bin/CYGWIN_NT-5.1-i686/') or \
                     self.filename == 'BaseTools/BuildEnv' or \
-                    self.filename.endswith('CODEOWNERS') or \
-                    self.filename.endswith('REVIEWERS'):
+                    self.filename in ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'] or \
+                    self.filename in ['REVIEWERS', '.github/REVIEWERS', 'docs/REVIEWERS']:
                     #
                     # Do not enforce CR/LF line endings for linux shell scripts.
                     # Some linux shell scripts don't end with the ".sh" extension,


### PR DESCRIPTION
Update PatchCheck.py to support all possible CODEOWNERS and REVIEWERS file locations.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>