### PR TITLE
.github: Fix path to UefiPayloadPkg in REVIEWERS

### DIFF
--- a/.github/REVIEWERS
+++ b/.github/REVIEWERS
@@ -857,7 +857,7 @@
 # M: James Lu <james.lu@intel.com> [jameslu8]
 # R: Gua Guo <gua.guo@intel.com> [gguo11837463]
 # S: Maintained
-/UefiPalyloadPkg/**  @gguo11837463
+/UefiPayloadPkg/**  @gguo11837463
 
 # UnitTestFrameworkPkg
 # F: UnitTestFrameworkPkg/


### PR DESCRIPTION
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>