### PR TITLE
.github: Add stewards as codeowners for CODEOWNERS and REVIEWERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,13 +121,17 @@
 # R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
 /.azurepipelines/**  @spbrogan @corthon
 
-# .github/
-# F: .github/
+# Tianocore Stewards must approve changes to CODEOWNERS and REVIEWERS
+/.github/CODEOWNERS   @ajfish  @leiflindholm  @mdkinney
+/.github/REVIEWERS    @ajfish  @leiflindholm  @mdkinney
+
+# .github/workflows/
+# F: .github/workflows/
 # M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
 # M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
 # R: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
 # R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
-/.github/**  @mdkinney @makubacki
+/.github/workflows/**  @mdkinney @makubacki
 
 # .mergify/
 # F: .mergify/

--- a/.github/REVIEWERS
+++ b/.github/REVIEWERS
@@ -120,13 +120,13 @@
 # R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
 /.azurepipelines/**  @mdkinney @lgao4
 
-# .github/
-# F: .github/
+# .github/workflows/
+# F: .github/workflows/
 # M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
 # M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
 # R: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]
 # R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
-/.github/**  @spbrogan @lgao4
+/.github/workflows/**  @spbrogan @lgao4
 
 # .mergify/
 # F: .mergify/

--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -111,8 +111,20 @@ M: Bret Barkelew <Bret.Barkelew@microsoft.com> [corthon]
 R: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
 R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
 
-.github/
-F: .github/
+.github/CODEOWNERS
+F: .github/CODEOWNERS
+M: Andrew Fish <afish@apple.com> [ajfish]
+M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+
+.github/REVIEWERS
+F: .github/REVIEWERS
+M: Andrew Fish <afish@apple.com> [ajfish]
+M: Leif Lindholm <quic_llindhol@quicinc.com> [leiflindholm]
+M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
+
+.github/workflows/
+F: .github/workflows/
 M: Michael D Kinney <michael.d.kinney@intel.com> [mdkinney]
 M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
 R: Sean Brogan <sean.brogan@microsoft.com> [spbrogan]


### PR DESCRIPTION
Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>